### PR TITLE
catch validation failed errors and halt

### DIFF
--- a/app/routes/v1/users.rb
+++ b/app/routes/v1/users.rb
@@ -21,11 +21,7 @@ module Api
 
         user = User.new(params.slice(:name, :email, :password))
 
-        begin
-          json user.save
-        rescue Sequel::ValidationFailed
-          halt_unprocessible_entity(user)
-        end
+        json user.save
       end
 
     end

--- a/config/initializers/error_handling.rb
+++ b/config/initializers/error_handling.rb
@@ -58,6 +58,10 @@ module Sinatra
         halt_not_found("Endpoint '#{request.path_info}' not found")
       end
 
+      app.error Sequel::ValidationFailed do |e|
+        halt_unprocessible_entity(e)
+      end
+
       app.error do
         # err_name = env['sinatra.error'].name
         halt_internal_server_error


### PR DESCRIPTION
http://sequel.jeremyevans.net/rdoc/classes/Sequel/ValidationFailed.html

The exception gives access to errors and the model, so it hooked right into the existing `halt_unprocessible_entity` method.