### PR TITLE
Explicitly use Rack::Static to serve static files

### DIFF
--- a/app/routes/base.rb
+++ b/app/routes/base.rb
@@ -14,7 +14,7 @@ module Api
 
       configure do
         enable :raise_errors
-        disable :dump_errors, :show_exceptions, :logging
+        disable :dump_errors, :show_exceptions, :logging, :static
 
         before { content_type(:json) }
 

--- a/config.ru
+++ b/config.ru
@@ -6,6 +6,12 @@ require "sidekiq/web"
 require "rack/ssl"
 require "rack-timeout"
 
+STATIC_PATHS ||= %w[/favicon.ico /robots.txt /docs].map(&:freeze)
+
+use Rack::Static, root: File.expand_path(__dir__ + "/public"),
+                  urls: STATIC_PATHS,
+                  cache_control: "public, max-age=31536000"
+
 use ExceptionHandling
 use Rack::Timeout, service_timeout: 10
 use Rack::HealthCheck

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,4 @@
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
 User-agent: *
+Disallow: /

--- a/spec/api/static_spec.rb
+++ b/spec/api/static_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe Api::Routes::Main, type: :api do
+  describe "requesting static files" do
+    it do
+      get "/robots.txt"
+      expect(http_status).to eq 200
+      expect(last_response.body).to include("Disallow")
+    end
+  end
+end


### PR DESCRIPTION
Explicitly use Rack::Static to serve static files rather than allowing sinatra to implicitly serve them